### PR TITLE
Change handling of the base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ updated at any time by running `grid configure`.
     GRiD Username: johnsmith
     GRiD Password:
     GRiD API Key: MyAPI-key
+    GRiD Base URL: https://rsgis.erdc.dren.mil/te_ba/
 
 This will create (or update) the configuration file in `$HOME/.grid/credentials`
 on Linux/Mac OS X, or `%HOMEPATH%/.grid/credentials` on Windows. This
@@ -154,9 +155,10 @@ func main() {
   // and the user's password.
   auth := base64.StdEncoding.EncodeToString([]byte("johnsmith:password"))
 
-  // A GRiD client is created by providing the authorization string and API key,
-  // both as strings.
-  g := grid.NewClient(auth, "MyAPI-key")
+  // A GRiD client is created by providing the authorization string, API key,
+  // and base URL as strings. If the base URL is empty, the default Test &
+  // Evaluation instance of GRiD will be targeted.
+  g := grid.NewClient(auth, "MyAPI-key", "")
 
   // Get details of the AOI with primary key of 100. The GRiD client does not
   // panic or set any HTTP status codes on error. Errors are returned from each

--- a/cli/grid/cmd/cmd.go
+++ b/cli/grid/cmd/cmd.go
@@ -58,5 +58,5 @@ func Execute() {
 func init() {
 	// setup the GRiD client
 	config := getConfig()
-	g = grid.NewClient(config.Auth, config.Key)
+	g = grid.NewClient(config.Auth, config.Key, config.URL)
 }

--- a/examples/pzsvc-grid/main.go
+++ b/examples/pzsvc-grid/main.go
@@ -111,7 +111,7 @@ var g *grid.Grid
 
 func init() {
 	config := getConfig()
-	g = grid.NewClient(config.Auth, config.Key)
+	g = grid.NewClient(config.Auth, config.Key, "")
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {

--- a/grid.go
+++ b/grid.go
@@ -342,12 +342,15 @@ func sanitizeURL(uri *url.URL) *url.URL {
 }
 
 // NewClient returns a new GRiD API client.
-func NewClient(auth, key string) *Grid {
-	baseURL, _ := url.Parse(defaultBaseURL)
+func NewClient(auth, key, baseURL string) *Grid {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	parsedBaseURL, _ := url.Parse(baseURL)
 	return &Grid{
 		Auth:    auth,
 		Key:     key,
-		BaseURL: baseURL,
+		BaseURL: parsedBaseURL,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},


### PR DESCRIPTION
We still provide a default URL, pointing to the Test and Evaluation instance of
GRiD. If consumers of the SDK wish to point to another instance, a different
base URL can be provided as part of the GRiD client constructor NewClient().
The base URL field of the client can also be set directly at any time.

The configure subcommand of the CLI has been updated to store the base URL as
part of the configuration file. Flags have been added to configure to allow
updates to the base URL and API key fields alone (username and password coming
soon).
