### PR TITLE
Move configuration back to GRiD SDK (from CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,80 @@ To get export task status:
 
 ## Using the library
 
+### Basic usage
+
 Simply create a GRiD client, and then begin making requests.
 
 ```go
 package main
 
+import "github.com/venicegeo/grid-sdk-go"
+
+func main() {
+  // Most users of the GRiD SDK simply need to create the client as shown. This
+  // call will retrieve credentials, the API key, and base URL from the
+  // configuration file and create the GRiD client accordingly.
+  g := grid.New()
+  if g == nil {
+    panic("There must not be a credentials file!")
+  }
+
+  // Get details of the AOI with primary key of 100. The GRiD client does not
+  // panic or set any HTTP status codes on error. Errors are returned from each
+  // request, along with the HTTP response, for consumers of the SDK to act on
+  // these as they see fit.
+  aoiListObject, _, err := g.GetAOI(100)
+  if err != nil {
+    panic(err)
+  }
+}
+```
+
+### Configuration
+
+This example demonstrates the usage of `GetConfig()` to check for valid configuration settings prior to creating the client.
+
+```go
+package main
+
+import "github.com/venicegeo/grid-sdk-go"
+
+func main() {
+  // The SDK provides a function to parse an existing config file and return the
+  // authorization string, API key, and base URL as a struct. While the config
+  // is not used in this context, it may be useful to ensure that the config
+  // file exists and is valid prior to creating the client.
+  _, err := grid.GetConfig()
+  if err != nil {
+    panic(err)
+  }
+
+  // As before, we create a new client, and get details on the AOI with primary
+  // key of 100.
+  g := grid.New()
+  if g == nil {
+    panic("Are you sure the configuration file is valid?")
+  }
+
+  aoiListObject, _, err := g.GetAOI(100)
+  if err != nil {
+    panic(err)
+  }
+}
+```
+
+### Advanced usage
+
+For now, the GRiD client can also be constructed directly, bypassing the credentials file altogether.
+
+```go
+package main
+
 import (
+  "crypto/tls"
   "encoding/base64"
+  "net/http"
+  "net/url"
 
   "github.com/venicegeo/grid-sdk-go"
 )
@@ -155,15 +222,63 @@ func main() {
   // and the user's password.
   auth := base64.StdEncoding.EncodeToString([]byte("johnsmith:password"))
 
-  // A GRiD client is created by providing the authorization string, API key,
-  // and base URL as strings. If the base URL is empty, the default Test &
-  // Evaluation instance of GRiD will be targeted.
-  g := grid.NewClient(auth, "MyAPI-key", "")
+  // The GRiD client expects the base URL to be provided as type URL, so we
+  // begin by parsing the provided URL string.
+  baseURL, _ := url.Parse("https://rsgis.erdc.dren.mil/te_ba/")
 
-  // Get details of the AOI with primary key of 100. The GRiD client does not
-  // panic or set any HTTP status codes on error. Errors are returned from each
-  // request, along with the HTTP response, for consumers of the SDK to act on
-  // these as they see fit.
-  aoiListObject, resp, err := g.GetAOI(100)
+  // For users wishing to construct the GRiD client directly (perhaps with a
+  // different transport), this is entirely possible.
+  g = &grid.Grid{
+    Auth:    auth,
+    Key:     "MyAPI-key",
+    BaseURL: baseURL,
+    Transport: &http.Transport{
+      TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+    },
+  }
+
+  // We can still use this client to get the AOI with primary key of 100.
+  aoiListObject, _, err := g.GetAOI(100)
+  if err != nil {
+    panic(err)
+  }
+}
+```
+
+## Configuration
+
+One method of obtaining GRiD credentials (the only one currently supported) is to read them from a configuration file, thus avoiding the temptation to hard-code these sensitive values. The following example demonstrates the creation of a configuration file.
+
+```go
+package main
+
+import (
+  "encoding/base64"
+  "encoding/json"
+  "os"
+
+  "github.com/venicegeo/grid-sdk-go"
+)
+
+func main() {
+  // Begin by creating the configuration file. This function ensures that the
+  // file is created in one of the expected locations (platform-specific).
+  file, err := grid.CreateConfigFile()
+  if err != nil {
+    panic(err)
+  }
+  defer file.Close()
+
+  // As in our earlier example, we create a base64 encoded string composed of
+  // the user's username and password.
+  auth := base64.StdEncoding.EncodeToString([]byte("johnsmith:password"))
+
+  // We then create a GRiD configuration object consisting of the authorization
+  // string, API key, and base URL. If the base URL is empty, the default Test &
+  // Evaluation instance of GRiD will be targeted.
+  config := grid.Config{Auth: auth, Key: "MyAPI-key", URL: ""}
+
+  // This object is encoded as JSON in the configuration file.
+  json.NewEncoder(file).Encode(config)
 }
 ```

--- a/cli/grid/cmd/ls.go
+++ b/cli/grid/cmd/ls.go
@@ -27,7 +27,6 @@ import (
 
 var geom string
 
-// TODO(chambbj): pass pk(s) as argument(s), as with the other commands
 func init() {
 	lsCmd.Flags().StringVarP(&geom, "geom", "", "", "WKT Polygon")
 }


### PR DESCRIPTION
Add methods to
- create/update the configuration file (in it's expected location, which is platform-specific),
- get the current configuration, and
- add functions to isolate reading configuration values and the masked password.

`NewClient` is now just `New` and returns a nil GRiD object and error if there is a problem. This adheres to Go conventions (https://golang.org/doc/effective_go.html#package-names).

`New` now retrieves configuration details from the configuration file directly. Consumers may still check that configuration is valid prior to creating, but they are not required to pass these directly to the constructor.

Use `MkdirAll` rather than `Mkdir` to make the .grid directory only if it doesn't already exist (seemed to mostly be a problem on Windows).

Add hack to be able to reliably call `ReadStrings` on Windows immediately following call to `ReadPassword`.

On Windows, configuration files are stored in `USERPROFILE` only, not `HOMEPATH`, or as a backup, `USERPROFILE`.
