### PR TITLE
Provide a method for initializing the grid client within the CLI

### DIFF
--- a/cli/grid/cmd/add.go
+++ b/cli/grid/cmd/add.go
@@ -33,6 +33,12 @@ more WKT geometries.
 This function queries GRiD's Geonames endpoint with the provided geometries and
 automatically uses the returned values as the AOI names.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		err := initClient()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
 		if len(args) == 0 {
 			fmt.Println("Please provide a WKT geometry")
 			cmd.Usage()

--- a/cli/grid/cmd/cmd.go
+++ b/cli/grid/cmd/cmd.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -59,23 +60,15 @@ func Execute() {
 	}
 }
 
-func init() {
-	// Try once. We'll assume that on first run, we will get an error, which
-	// requires that we login.
+// initClient is called by each subcommand except configure. The reason is
+// simple. Configure can proceed without a valid client, and in fact is a
+// prerequisite to any other API call. If this weren't the case, it would be an
+// init() function.
+func initClient() error {
 	var err error
 	g, err = grid.New()
 	if err != nil {
-		fmt.Println("It looks like this is your first time running the GRiD CLI. Please follow the prompts to configure the CLI with your credentials.")
-		err := logon()
-		if err != nil {
-			panic("Error creating credentials file!")
-		}
-
-		// After that, things should work fine. If we've got a problem now, then
-		// panic!
-		g, err = grid.New()
-		if err != nil {
-			panic(err)
-		}
+		return errors.New("It looks like this is your first time running the GRiD CLI.\nPlease run 'grid configure' to continue.")
 	}
+	return nil
 }

--- a/cli/grid/cmd/download.go
+++ b/cli/grid/cmd/download.go
@@ -28,6 +28,12 @@ var pullCmd = &cobra.Command{
 	Long: `
 Download the file(s) specified by the given primary key(s).`,
 	Run: func(cmd *cobra.Command, args []string) {
+		err := initClient()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
 		for _, arg := range args {
 			pk, err := strconv.Atoi(arg)
 			if err != nil {

--- a/cli/grid/cmd/export.go
+++ b/cli/grid/cmd/export.go
@@ -30,6 +30,12 @@ var exportCmd = &cobra.Command{
 	Long: `
 Export is used to initiate a GRiD export for the AOI and for each of the provided collects.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		err := initClient()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
 		var collects []string
 		switch len(args) {
 		case 0:

--- a/cli/grid/cmd/lookup.go
+++ b/cli/grid/cmd/lookup.go
@@ -28,6 +28,12 @@ var lookupCmd = &cobra.Command{
 Lookup is used to retrieve a suggested AOI name from GRiD's Geonames endpoint
 for each of the provided WKT geometries.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		err := initClient()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
 		if len(args) == 0 {
 			fmt.Println("Please provide a WKT geometry")
 			cmd.Usage()

--- a/cli/grid/cmd/ls.go
+++ b/cli/grid/cmd/ls.go
@@ -40,6 +40,12 @@ List AOI, export, or file details for the provided primary keys.
 With no keys specified, the command returns a listing of all of the user's
 AOIs.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		err := initClient()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
 		listAOIs := false
 		if len(args) == 0 || geom != "" {
 			listAOIs = true

--- a/cli/grid/cmd/task.go
+++ b/cli/grid/cmd/task.go
@@ -29,6 +29,12 @@ var taskCmd = &cobra.Command{
 	Long: `
 Lookup is used to retrieve the details of a GRiD task, including the status.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		err := initClient()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
 		if len(args) == 0 {
 			fmt.Println("Please provide a WKT geometry")
 			cmd.Usage()


### PR DESCRIPTION
Subcommands that require the client will initialize, but stuffing this in package `init()` doesn't make sense, as the `configure` subcommand would then not work.
